### PR TITLE
fix utf8 encoding on build

### DIFF
--- a/tgarchive/build.py
+++ b/tgarchive/build.py
@@ -113,7 +113,7 @@ class Build:
                                     make_filename=self.make_filename,
                                     nl2br=self._nl2br)
 
-        with open(os.path.join(self.config["publish_dir"], fname), "w") as f:
+        with open(os.path.join(self.config["publish_dir"], fname), "w", encoding='utf8') as f:
             f.write(html)
 
     def _build_rss(self, messages, rss_file, atom_file):


### PR DESCRIPTION
`
C:\Users\me\Downloads\mysite>tg-archive --build
2021-06-16 21:27:26,443: building site
Traceback (most recent call last):
  File "c:\python39\lib\runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "c:\python39\lib\runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "C:\Python39\Scripts\tg-archive.exe\__main__.py", line 7, in <module>
  File "c:\python39\lib\site-packages\tgarchive\__init__.py", line 133, in main
    b.build()
  File "c:\python39\lib\site-packages\tgarchive\build.py", line 83, in build
    self._render_page(messages, month, dayline,
  File "c:\python39\lib\site-packages\tgarchive\build.py", line 117, in _render_page
    f.write(html)
  File "c:\python39\lib\encodings\cp1251.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode character '\u0306' in position 53273: character maps to <undefined>

`
`
