### PR TITLE
Add takeout mode

### DIFF
--- a/tgarchive/__init__.py
+++ b/tgarchive/__init__.py
@@ -111,7 +111,7 @@ def main():
         from .sync import Sync
 
         cfg = get_config(args.config)
-        mode = "takeout" if "use_takeout" in cfg else "standard"
+        mode = "takeout" if cfg.get("use_takeout", False) else "standard"
         logging.info("starting Telegram sync (batch_size={}, limit={}, wait={}, mode={})".format(
             cfg["fetch_batch_size"], cfg["fetch_limit"], cfg["fetch_wait"], mode
         ))
@@ -120,7 +120,7 @@ def main():
             s.sync(args.id)
         except KeyboardInterrupt as e:
             logging.info("sync cancelled manually")
-            if "use_takeout" in cfg:
+            if cfg.get("use_takeout", False):
                 s.finish_takeout()
             quit()
         except:

--- a/tgarchive/__init__.py
+++ b/tgarchive/__init__.py
@@ -111,7 +111,7 @@ def main():
         from .sync import Sync
 
         cfg = get_config(args.config)
-        mode = "takeout" if cfg["use_takeout"] else "standard"
+        mode = "takeout" if "use_takeout" in cfg else "standard"
         logging.info("starting Telegram sync (batch_size={}, limit={}, wait={}, mode={})".format(
             cfg["fetch_batch_size"], cfg["fetch_limit"], cfg["fetch_wait"], mode
         ))
@@ -120,7 +120,7 @@ def main():
             s.sync(args.id)
         except KeyboardInterrupt as e:
             logging.info("sync cancelled manually")
-            if cfg["use_takeout"]:
+            if "use_takeout" in cfg:
                 s.finish_takeout()
             quit()
         except:

--- a/tgarchive/example/config.yaml
+++ b/tgarchive/example/config.yaml
@@ -17,14 +17,12 @@ media_dir: "media"
 # Takeout mode allows you to fetch messages at a higher rate than the standard mode.
 # It is the method used in the desktop client to export data.
 # You can use a larger fetch_batch_size. Set this as False to use the standard mode.
-use_takeout: True
+use_takeout: False
 
 # These should be configured carefully to not get rate limited by Telegram.
 # Number of messages to fetch in one batch.
-# For takeout mode (use_takeout: True)
-fetch_batch_size: 4000
-# For standard mode (use_takeout: False)
-# fetch_batch_size: 2000
+# For takeout mode (use_takeout: True), this value can be greater.
+fetch_batch_size: 2000
 
 # Seconds to wait after fetching one full batch and moving on to the next one.
 fetch_wait: 5

--- a/tgarchive/example/config.yaml
+++ b/tgarchive/example/config.yaml
@@ -14,9 +14,17 @@ download_avatars: True
 avatar_size: [64, 64] # Width, Height.
 media_dir: "media"
 
+# Takeout mode allows you to fetch messages at a higher rate than the standard mode.
+# It is the method used in the desktop client to export data.
+# You can use a larger fetch_batch_size. Set this as False to use the standard mode.
+use_takeout: True
+
 # These should be configured carefully to not get rate limited by Telegram.
 # Number of messages to fetch in one batch.
-fetch_batch_size: 2000
+# For takeout mode (use_takeout: True)
+fetch_batch_size: 4000
+# For standard mode (use_takeout: False)
+# fetch_batch_size: 2000
 
 # Seconds to wait after fetching one full batch and moving on to the next one.
 fetch_wait: 5

--- a/tgarchive/sync.py
+++ b/tgarchive/sync.py
@@ -144,7 +144,6 @@ class Sync:
                     wait_time = None
                 messages = self.client.get_messages(group, offset_id=offset_id, limit=self.config["fetch_batch_size"],
                                                     wait_time=wait_time, ids=ids, reverse=True)
-                logging.info("Took out {} messages".format(len(messages)))
                 return messages
             except errors.FloodWaitError as e:
                 logging.info("flood waited: have to wait {} seconds".format(e.seconds))

--- a/tgarchive/sync.py
+++ b/tgarchive/sync.py
@@ -89,7 +89,7 @@ class Sync:
                 break
 
         self.db.commit()
-        if self.config["use_takeout"]:
+        if "use_takeout" in self.config:
             self.finish_takeout()
         logging.info(
             "finished. fetched {} messages. last message = {}".format(n, last_date))
@@ -97,7 +97,7 @@ class Sync:
     def new_client(self, session, config):
         client = TelegramClient(session, config["api_id"], config["api_hash"])
         client.start()
-        if config["use_takeout"]:
+        if "use_takeout" in config:
             for retry in range(3):
                 try:
                     takeout_client = client.takeout(finalize=True).__enter__()

--- a/tgarchive/sync.py
+++ b/tgarchive/sync.py
@@ -8,7 +8,7 @@ import shutil
 import time
 
 from PIL import Image
-from telethon import errors, TelegramClient
+from telethon import TelegramClient, errors, sync
 import telethon.tl.types
 
 from .db import User, Message, Media
@@ -89,7 +89,7 @@ class Sync:
                 break
 
         self.db.commit()
-        if "use_takeout" in self.config:
+        if self.config.get("use_takeout", False):
             self.finish_takeout()
         logging.info(
             "finished. fetched {} messages. last message = {}".format(n, last_date))
@@ -97,7 +97,7 @@ class Sync:
     def new_client(self, session, config):
         client = TelegramClient(session, config["api_id"], config["api_hash"])
         client.start()
-        if "use_takeout" in config:
+        if config.get("use_takeout", False):
             for retry in range(3):
                 try:
                     takeout_client = client.takeout(finalize=True).__enter__()
@@ -168,7 +168,7 @@ class Sync:
 
     def _fetch_messages(self, group, offset_id, ids=None) -> Message:
         try:
-            if self.config["use_takeout"]:
+            if self.config.get("use_takeout", False):
                 wait_time = 0
             else:
                 wait_time = None


### PR DESCRIPTION
**Fixes #6** 

**Takeout mode**
Takeout mode allows for faster export as requests are made with a takeout session. The flood limits are presumably more generous (lower) for such requests, allowing the user to experiment with a bigger fetch_batch_size. The user can opt for or opt out of the new takeout mode through the use_takeout option in the config file.

I believe that the takeout session was designed to export data and hence I took the liberty to set the use_takeout value to True in the example config, making it the default behavior for every new site. I have also set the fetch_batch_size as 4000. I did some testing and it seems to be good. We can discuss and make changes to these configs as needed.

**No avatar/profile photo handling**
[`download_profile_photo`](https://docs.telethon.dev/en/latest/modules/client.html?highlight=download_profile_photo#telethon.client.downloads.DownloadMethods.download_profile_photo) returns None when a user does not have a profile photo and tg-archive currently logs an unnecessary error ('cannot identify image file') when that happens. This has also been fixed.