### PR TITLE
Symlink files and directories when building

### DIFF
--- a/tgarchive/__init__.py
+++ b/tgarchive/__init__.py
@@ -82,6 +82,8 @@ def main():
                    dest="template", help="path to the template file")
     b.add_argument("-o", "--output", action="store", type=str, default="site",
                    dest="output", help="path to the output directory")
+    p.add_argument("--symlink", action="store_true", dest="symlink",
+                   help="use symlinks to save disk space")
 
     args = p.parse_args(args=None if sys.argv[1:] else ['--help'])
 
@@ -138,7 +140,7 @@ def main():
         from .build import Build
 
         logging.info("building site")
-        b = Build(get_config(args.config), DB(args.data))
+        b = Build(get_config(args.config), DB(args.data), args.symlink)
         b.load_template(args.template)
         b.build()
 

--- a/tgarchive/__init__.py
+++ b/tgarchive/__init__.py
@@ -82,7 +82,7 @@ def main():
                    dest="template", help="path to the template file")
     b.add_argument("-o", "--output", action="store", type=str, default="site",
                    dest="output", help="path to the output directory")
-    p.add_argument("--symlink", action="store_true", dest="symlink",
+    b.add_argument("--symlink", action="store_true", dest="symlink",
                    help="use symlinks to save disk space")
 
     args = p.parse_args(args=None if sys.argv[1:] else ['--help'])

--- a/tgarchive/__init__.py
+++ b/tgarchive/__init__.py
@@ -83,7 +83,7 @@ def main():
     b.add_argument("-o", "--output", action="store", type=str, default="site",
                    dest="output", help="path to the output directory")
     b.add_argument("--symlink", action="store_true", dest="symlink",
-                   help="use symlinks to save disk space")
+                   help="symlink media and other static files instead of copying")
 
     args = p.parse_args(args=None if sys.argv[1:] else ['--help'])
 

--- a/tgarchive/build.py
+++ b/tgarchive/build.py
@@ -20,9 +20,10 @@ class Build:
     template = None
     db = None
 
-    def __init__(self, config, db):
+    def __init__(self, config, db, symlink):
         self.config = config
         self.db = db
+        self.symlink = symlink
 
         # Map of all message IDs across all months and the slug of the page
         # in which they occur (paginated), used to link replies to their
@@ -85,7 +86,11 @@ class Build:
 
         # The last page chronologically is the latest page. Make it index.
         if fname:
-            os.symlink(fname, os.path.join(self.config["publish_dir"], "index.html"))
+            if self.symlink:
+                os.symlink(fname, os.path.join(self.config["publish_dir"], "index.html"))
+            else:
+                shutil.copy(os.path.join(self.config["publish_dir"], fname),
+                            os.path.join(self.config["publish_dir"], "index.html"))
 
         # Generate RSS feeds.
         if self.config["publish_rss_feed"]:
@@ -165,10 +170,19 @@ class Build:
         # Copy the static directory into the output directory.
         for f in [self.config["static_dir"]]:
             target = os.path.join(pubdir, f)
-            os.symlink(os.path.abspath(f), target)
+            if self.symlink:
+                os.symlink(os.path.abspath(f), target)
+            elif os.path.isfile(f):
+                shutil.copyfile(f, target)
+            else:
+                shutil.copytree(f, target)
 
-        # If media downloading is enabled, symlink the media directory.
+        # If media downloading is enabled, copy/symlink the media directory.
         mediadir = self.config["media_dir"]
         if os.path.exists(mediadir):
-            os.symlink(os.path.abspath(mediadir), os.path.join(
-                pubdir, os.path.basename(mediadir)))
+            if self.symlink:
+                os.symlink(os.path.abspath(mediadir), os.path.join(
+                    pubdir, os.path.basename(mediadir)))
+            else:
+                shutil.copytree(mediadir, os.path.join(
+                    pubdir, os.path.basename(mediadir)))

--- a/tgarchive/build.py
+++ b/tgarchive/build.py
@@ -85,8 +85,7 @@ class Build:
 
         # The last page chronologically is the latest page. Make it index.
         if fname:
-            shutil.copy(os.path.join(self.config["publish_dir"], fname),
-                        os.path.join(self.config["publish_dir"], "index.html"))
+            os.symlink(fname, os.path.join(self.config["publish_dir"], "index.html"))
 
         # Generate RSS feeds.
         if self.config["publish_rss_feed"]:
@@ -166,13 +165,10 @@ class Build:
         # Copy the static directory into the output directory.
         for f in [self.config["static_dir"]]:
             target = os.path.join(pubdir, f)
-            if os.path.isfile(f):
-                shutil.copyfile(f, target)
-            else:
-                shutil.copytree(f, target)
+            os.symlink(os.path.abspath(f), target)
 
-        # If media downloading is enabled, copy the media directory.
+        # If media downloading is enabled, symlink the media directory.
         mediadir = self.config["media_dir"]
         if os.path.exists(mediadir):
-            shutil.copytree(mediadir, os.path.join(
+            os.symlink(os.path.abspath(mediadir), os.path.join(
                 pubdir, os.path.basename(mediadir)))


### PR DESCRIPTION
This is preferred as copying takes much more time and uses up space.

Closes #42.