### PR TITLE
Store message content as HTML

### DIFF
--- a/tgarchive/build.py
+++ b/tgarchive/build.py
@@ -119,7 +119,8 @@ class Build:
                                     pagination={"current": page,
                                                 "total": total_pages},
                                     make_filename=self.make_filename,
-                                    nl2br=self._nl2br)
+                                    nl2br=self._nl2br,
+                                    replace_msg_link=self._replace_msg_link)
 
         with open(os.path.join(self.config["publish_dir"], fname), "w", encoding="utf8") as f:
             f.write(html)
@@ -165,7 +166,8 @@ class Build:
                                             m=m,
                                             media_mime=media_mime,
                                             page_ids=self.page_ids,
-                                            nl2br=self._nl2br)
+                                            nl2br=self._nl2br,
+                                            replace_msg_link=self._replace_msg_link)
         out = m.content
         if not out and m.media:
             out = m.media.title
@@ -174,7 +176,18 @@ class Build:
     def _nl2br(self, s) -> str:
         # There has to be a \n before <br> so as to not break
         # Jinja's automatic hyperlinking of URLs.
-        return _NL2BR.sub("\n\n", s).replace("\n", "\n<br />")
+        return _NL2BR.sub("\n\n", str(s)).replace("\n", "\n<br />")
+
+    def _replace_msg_link(self, s) -> str:
+        # Replace Telegram message links with site links
+        result = re.sub(r"<a href=\"(https://t\.me/{}/)(\d+)\">".format(self.config["group"]),
+                        self._sub_msg_link, s)
+        return result
+
+    def _sub_msg_link(self, match):
+        if self.page_ids.get(int(match.group(2))) is None:
+            return match.group(0)
+        return match.group(0).replace(match.group(1), self.page_ids[int(match.group(2))] + "#")
 
     def _create_publish_dir(self):
         pubdir = self.config["publish_dir"]

--- a/tgarchive/example/rss_template.html
+++ b/tgarchive/example/rss_template.html
@@ -31,7 +31,7 @@
     </div>
     <div class="text">
       {% if m.type == "message" %}
-      {{ nl2br(m.content | escape) | safe | urlize }}
+      {{ replace_msg_link(nl2br(m.content)) }}
       {% else %}
       {% if m.type == "user_joined" %}
       Joined.

--- a/tgarchive/example/template.html
+++ b/tgarchive/example/template.html
@@ -123,7 +123,7 @@
 							</div>
 							<div class="text">
 								{% if m.type == "message" %}
-									{{ nl2br(m.content | escape) | safe | urlize }}
+									{{ replace_msg_link(nl2br(m.content)) }}
 								{% else %}
 									{% if m.type == "user_joined" %}
 										Joined.

--- a/tgarchive/sync.py
+++ b/tgarchive/sync.py
@@ -97,6 +97,7 @@ class Sync:
     def new_client(self, session, config):
         client = TelegramClient(session, config["api_id"], config["api_hash"])
         client.start()
+        client.parse_mode = 'html'
         if config.get("use_takeout", False):
             for retry in range(3):
                 try:
@@ -160,7 +161,7 @@ class Sync:
                 id=m.id,
                 date=m.date,
                 edit_date=m.edit_date,
-                content=sticker if sticker else m.raw_text,
+                content=sticker if sticker else m.text,
                 reply_to=m.reply_to_msg_id if m.reply_to and m.reply_to.reply_to_msg_id else None,
                 user=self._get_user(m.sender),
                 media=med


### PR DESCRIPTION
Fixes #43 

Messages are stored in the database as HTML. This preserves formatting such as bold, italic, underline, strikethrough, monospace and inline links.
Telegram links in a message to other messages (t.me/group/message_id) are replaced with their archival site version.
For example, `t.me/example_group/12` becomes `example_group/site/2022-02.html#12`.