### PR TITLE
README: add workaround for opaque failure mode of app creation page

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ tg-archive uses the [Telethon](https://github.com/LonamiWebs/Telethon) Telegram 
 
 ## Install
 - Get [Telegram API credentials](https://my.telegram.org/auth?to=apps). Normal user account API and not the Bot API.
+  - If this page produces an alert stating only "ERROR", disconnect from any proxy/vpn and try again in a different browser.
 - Install with `pip3 install tg-archive` (tested with Python 3.8.6).
 
 ### Usage


### PR DESCRIPTION
The `my.telegram.org` new app page does not like proxied connections or certain browsers (multiple flavors of chrome/chromium at minimum). Form submission will always fail under some conditions. The page will emit an alert box with no error code, only the text "ERROR". Frustration with this error is common and discussion always converges on "disable VPN" and "try a different browser" or "try your phone's browser" as fixes. This PR preempts needless debugging attempts.

Examples in the wild:
- https://github.com/tdlib/telegram-bot-api/issues/273
- https://stackoverflow.com/questions/38104560/telegram-api-create-new-application-error