### PR TITLE
fix "module 'PIL.Image' has no attribute 'ANTIALIAS'"

### DIFF
--- a/tgarchive/sync.py
+++ b/tgarchive/sync.py
@@ -357,7 +357,7 @@ class Sync:
             return None
 
         im = Image.open(b)
-        im.thumbnail(self.config["avatar_size"], Image.ANTIALIAS)
+        im.thumbnail(self.config["avatar_size"], Image.LANCZOS)
         im.save(fpath, "JPEG")
 
         return fname


### PR DESCRIPTION
Fixes "error downloading avatar: #XXXXXXX: module 'PIL.Image' has no attribute 'ANTIALIAS'" due to removed Image.ANTIALIAS in Pillow 10

https://pillow.readthedocs.io/en/stable/releasenotes/10.0.0.html#constants