### PR TITLE
Fix proxy support in windows

### DIFF
--- a/tgarchive/sync.py
+++ b/tgarchive/sync.py
@@ -96,8 +96,11 @@ class Sync:
 
     def new_client(self, session, config):
         if "proxy" in config and config["proxy"].get("enable"):
+            # support windows
+            # upstream issue https://github.com/LonamiWebs/Telethon/issues/3962
+            mapping = {'socks4': 1, 'socks5': 2, 'http': 3}
             proxy = config["proxy"]
-            client = TelegramClient(session, config["api_id"], config["api_hash"], proxy=(proxy["protocol"], proxy["addr"], proxy["port"]))
+            client = TelegramClient(session, config["api_id"], config["api_hash"], proxy=(mapping.get(proxy['protocol']), proxy['addr'], proxy['port']))
         else:
             client = TelegramClient(session, config["api_id"], config["api_hash"])
         # hide log messages


### PR DESCRIPTION
Setting the proxy on windows doesn't work.

socks.SOCKS4 = 1
socks.SOCKS5 = 2
socks.HTTP = 3

upstream issue: https://github.com/LonamiWebs/Telethon/issues/3962
telethon document: https://docs.telethon.dev/en/stable/basic/signing-in.html?highlight=proxy#signing-in-behind-a-proxy