### PR TITLE
Uppercase extension support and .oga support

### DIFF
--- a/tgarchive/example/template.html
+++ b/tgarchive/example/template.html
@@ -158,8 +158,8 @@
 											</ul>
 										</div>									
 									{% elif m.media.type == "photo" %}
-										{% set ext = m.media.url.split('/')[-1].split('.')[-1] %}
-										{% if ext in ['mp4', 'webm', 'ogg', 'ogv', 'mov'] %}
+										{% set ext = m.media.url.split('/')[-1].split('.')[-1].lower() %}
+										{% if ext in ['mp4', 'webm', 'ogg', 'ogv', 'oga', 'mov'] %}
 											<video controls>
 												<source src="{{ config.media_dir }}/{{ m.media.url }}">
 											</video>


### PR DESCRIPTION
Video and audio players weren't present when the original filename had an uppercase extension. This PR fixes this and adds media players for .oga files