### PR TITLE
Replace pkg_resources with importlib.metadata for version retrieval

### DIFF
--- a/tgarchive/build.py
+++ b/tgarchive/build.py
@@ -1,8 +1,8 @@
 from collections import OrderedDict, deque
+from importlib.metadata import version
 import logging
 import math
 import os
-import pkg_resources
 import re
 import shutil
 import magic
@@ -131,7 +131,7 @@ class Build:
         f = FeedGenerator()
         f.id(self.config["site_url"])
         f.generator(
-            "tg-archive {}".format(pkg_resources.get_distribution("tg-archive").version))
+            "tg-archive {}".format(version("tg-archive")))
         f.link(href=self.config["site_url"], rel="alternate")
         f.title(self.config["site_name"].format(group=self.config["group"]))
         f.subtitle(self.config["site_description"])


### PR DESCRIPTION
I ran into a problem when executing the command `tg-archive --build`:
`ModuleNotFoundError: No module named 'pkg_resources'`
From python 3.12 module `pkg_resources` isn't available by default.

Recommended method instead deprecated [pkg_resources](https://setuptools.pypa.io/en/latest/pkg_resources.html) is [importlib.metadata](https://docs.python.org/3.12/library/importlib.metadata.html)
It was added in python3.8, so there shouldn't be any compatibility issues.

https://docs.python.org/3/whatsnew/3.12.html

> [gh-95299](https://github.com/python/cpython/issues/95299): Do not pre-install setuptools in virtual environments created with [venv](https://docs.python.org/3/library/venv.html#module-venv). This means that distutils, setuptools, pkg_resources, and easy_install will no longer available by default; to access these run pip install setuptools in the [activated](https://docs.python.org/3/library/venv.html#venv-explanation) virtual environment.