### PR TITLE
Fix AttributeError when reply_to is None (#150)

### DIFF
--- a/tgarchive/sync.py
+++ b/tgarchive/sync.py
@@ -181,7 +181,7 @@ class Sync:
                 date=m.date,
                 edit_date=m.edit_date,
                 content=sticker if sticker else m.raw_text,
-                reply_to=m.reply_to_msg_id if m.reply_to and m.reply_to.reply_to_msg_id else None,
+                reply_to=getattr(m.reply_to, "reply_to_msg_id", None),
                 user=self._get_user(m.sender, m.chat),
                 media=med
             )


### PR DESCRIPTION
Use getattr instead of an if conditional to get the m.reply_to.reply_to_msg_id attribute. This way if `m` is None, the program doesn't break.

Fixes #150