### PR TITLE
display audio files with an html audio tag, not video tag.  

### DIFF
--- a/tgarchive/example/template.html
+++ b/tgarchive/example/template.html
@@ -159,10 +159,15 @@
 										</div>									
 									{% elif m.media.type == "photo" %}
 										{% set ext = m.media.url.split('/')[-1].split('.')[-1].lower() %}
-										{% if ext in ['mp4', 'webm', 'ogg', 'ogv', 'oga', 'mov'] %}
+										{% if ext in ['mp4', 'webm', 'ogg', 'ogv', 'mov'] %}
 											<video controls>
 												<source src="{{ config.media_dir }}/{{ m.media.url }}">
 											</video>
+											<p><a href="{{ config.media_dir }}/{{ m.media.url }}">{{ m.media.title }}</a></p>
+										{% elif ext in ['oga', 'mp3', 'wav'] %}
+											<audio controls>
+												<source src="{{ config.media_dir }}/{{ m.media.url }}">
+											</audio>
 											<p><a href="{{ config.media_dir }}/{{ m.media.url }}">{{ m.media.title }}</a></p>
 										{% elif ext in ['webp'] %}
 											<a href="{{ config.media_dir }}/{{ m.media.url }}">


### PR DESCRIPTION
additionally, add supported mp3 and wav formats to the audio tag.

It looks cleaner when the static site is built.